### PR TITLE
Using stringWithUTF8String

### DIFF
--- a/src/ofxHAPAVPlayer.mm
+++ b/src/ofxHAPAVPlayer.mm
@@ -78,7 +78,7 @@ void ofxHAPAVPlayer::load(string path){
     
     bFrameNew = false;
     
-    NSString *nsPath = [NSString stringWithCString:ofToDataPath(path).c_str() encoding:[NSString defaultCStringEncoding]];
+    NSString *nsPath = [NSString stringWithUTF8String:ofToDataPath(path).c_str()];
     [delegate load:nsPath];
     
 }


### PR DESCRIPTION
"stringWithCString" method can not open multi byte named file.

"stringWithUTF8String" is better. refs,

https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/video/ofAVFoundationPlayer.mm#L70

